### PR TITLE
[Joins with WHERE] Add columns to be selected into exercise prompt

### DIFF
--- a/sqlteaching.js
+++ b/sqlteaching.js
@@ -464,7 +464,7 @@ var levels = [
       values: [["Doogie Howser", "Doogie Howser, M.D."]],
     },
     prompt:
-      'You can also use joins with the <code>WHERE</code> clause. <br/><br/> To get a list of characters and TV shows that are not in "Buffy the Vampire Slayer" and are not Barney Stinson, you would run: <br/> <code>SELECT character.name, tv_show.name<br/> FROM character <br/>INNER JOIN character_tv_show<br/> ON character.id = character_tv_show.character_id<br/>INNER JOIN tv_show<br/> ON character_tv_show.tv_show_id = tv_show.id WHERE character.name != \'Barney Stinson\' AND tv_show.name != \'Buffy the Vampire Slayer\';</code> <br/><br/>Can you return a list of characters and TV shows that are not named "Willow Rosenberg" and not in the show "How I Met Your Mother"?',
+      'You can also use joins with the <code>WHERE</code> clause. <br/><br/> To get a list of characters and TV shows that are not in "Buffy the Vampire Slayer" and are not Barney Stinson, you would run: <br/> <code>SELECT character.name, tv_show.name<br/> FROM character <br/>INNER JOIN character_tv_show<br/> ON character.id = character_tv_show.character_id<br/>INNER JOIN tv_show<br/> ON character_tv_show.tv_show_id = tv_show.id WHERE character.name != \'Barney Stinson\' AND tv_show.name != \'Buffy the Vampire Slayer\';</code> <br/><br/>Can you return a list of characters and TV shows that are not named "Willow Rosenberg" and not in the show "How I Met Your Mother"?<br/>Select the columns: <strong>character</strong><em>.name</em>, <strong>tv_show</strong><em>.name</em>',
   },
 
   {


### PR DESCRIPTION
## What does this PR do?

- Simply adds an extra phrase to **Joins with WHERE** exercise prompt to help with clarity on which columns need to be selected for the result;

**Before changes:**

![before_changes](https://github.com/user-attachments/assets/4d2094a6-29b1-433e-b7d4-ce60c08c6fb2)

**After changes:**

![after_changes](https://github.com/user-attachments/assets/9d655439-ae29-4114-860d-33cfce6e14a2)